### PR TITLE
update typings

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,4 @@
-export function add(runMe: function): function;
+export function add(runMe: Function): Function;
 
 export function runAll()
 export function removeAll()


### PR DESCRIPTION
ERROR in /electron-app/node_modules/unload/src/index.d.ts (1,28): Type expected.

ERROR in /electron-app/node_modules/unload/src/index.d.ts (1,36): '(' expected.

ERROR in /electron-app/node_modules/unload/src/index.d.ts (1,39): Type expected.

ERROR in /electron-app/node_modules/unload/src/index.d.ts (1,47): Identifier expected.

ERROR in /electron-app/node_modules/unload/src/index.d.ts (1,21): A parameter initializer is only allowed in a function or constructor implementation.

I get this errors in the typings when trying to build an angular 4.4.6 app + rxdb 7.0.0, with typescript 2.6